### PR TITLE
Pass dbUrl and dbPrefix as service options

### DIFF
--- a/src/build-connection-url.js
+++ b/src/build-connection-url.js
@@ -1,0 +1,6 @@
+export default function (url, prefix, locationGroup) {
+  let connectionUrl = url;
+  if (prefix) connectionUrl += '/' + prefix;
+  if (locationGroup) connectionUrl += '-' + locationGroup;
+  return connectionUrl;
+}

--- a/src/multi-service.js
+++ b/src/multi-service.js
@@ -4,16 +4,15 @@ import getService from './service-proxy';
 export default ({
   app = null,
   collectionName = null,
-  schema = null
+  schema = null,
+  dbUrl = app.get('dbUrl'),
+  dbPrefix = app.get('dbPrefix')
 }) => {
   if (!app || !collectionName || !schema) {
     throw new Error(
       'Wrong multi service usage. Required schema, app, collectionName'
     );
   }
-
-  const dbUrl = app.get('dbUrl');
-  const dbPrefix = app.get('dbPrefix');
 
   return service({
     collectionName,

--- a/src/service-proxy.js
+++ b/src/service-proxy.js
@@ -1,20 +1,15 @@
-import errors from 'feathers-errors';
 import mongoose from 'mongoose';
 import service from 'feathers-mongoose';
 import Promise from 'bluebird';
+import buildConnectionUrl from './build-connection-url';
 
 mongoose.Promise = Promise;
 
-const services = { };
+const services = {};
 
 export default function (params) {
   const locationGroup = params.locationGroup;
-
-  if (!locationGroup) throw new errors.BadRequest('locationGroup must be defined');
-
-  delete params.locationGroup;
-
-  const connectionUrl = `${this.dbUrl}/${this.dbPrefix}-${locationGroup}`;
+  const connectionUrl = buildConnectionUrl(this.dbUrl, this.dbPrefix, locationGroup);
   const serviceName = `${connectionUrl}/${this.collectionName}`;
 
   if (!services[serviceName]) {

--- a/test/build-connection-url.test.js
+++ b/test/build-connection-url.test.js
@@ -1,0 +1,38 @@
+import test from 'ava';
+import { assert } from 'chai';
+import fn from '../src/build-connection-url';
+
+test('should properly build url with prefix and location group', () => {
+  const url = 'mongodb://localhost';
+  const prefix = 'testdb';
+  const locationGroup = 'location1';
+
+  const expected = `${url}/${prefix}-${locationGroup}`;
+  const result = fn(url, prefix, locationGroup);
+  assert.equal(result, expected);
+});
+
+test('should properly build url with only location group', () => {
+  const url = 'mongodb://localhost/testdb';
+  const locationGroup = 'location1';
+
+  const expected = `${url}-${locationGroup}`;
+  const result = fn(url, null, locationGroup);
+  assert.equal(result, expected);
+});
+
+test('should properly build url with only prefix', () => {
+  const url = 'mongodb://localhost';
+  const prefix = 'testdb';
+
+  const expected = `${url}/${prefix}`;
+  const result = fn(url, prefix);
+  assert.equal(result, expected);
+});
+
+test('should properly build url without prefix and location group', () => {
+  const url = 'mongodb://localhost/testdb';
+
+  const result = fn(url);
+  assert.equal(result, url);
+});

--- a/test/multi-service.test.js
+++ b/test/multi-service.test.js
@@ -31,3 +31,34 @@ test('should return a multi-service instance', () => {
 
   assert.isObject(service(options));
 });
+
+test('should return a dbUrl and dbPrefix from config', () => {
+  const config = { dbUrl: 'mongodb://localhost', dbPrefix: 'some' };
+  const options = {
+    app: {
+      get(key) {
+        return config[key];
+      }
+    },
+    collectionName: 'test',
+    schema: {}
+  };
+
+  const result = service(options);
+  assert.equal(result.dbUrl, config.dbUrl);
+  assert.equal(result.dbPrefix, config.dbPrefix);
+});
+
+test('should return a dbUrl and dbPrefix from options', () => {
+  const options = {
+    app: { },
+    collectionName: 'test',
+    schema: {},
+    dbUrl: 'mongodb://localhost',
+    dbPrefix: 'some'
+  };
+
+  const result = service(options);
+  assert.equal(result.dbUrl, options.dbUrl);
+  assert.equal(result.dbPrefix, options.dbPrefix);
+});


### PR DESCRIPTION
Do not remove locationGroup params in hooks for multiple time usage
Make location group optional
Make db prefix optional